### PR TITLE
use JRestless version 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.jrestless.fnproject</groupId>
             <artifactId>jrestless-fnproject-core</artifactId>
-            <version>0.5.2-SNAPSHOT</version>
+            <version>0.6.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
use JRestless version 0.6.0 which is available in jcenter

Probably https://github.com/fnproject/fn-jrestless-example/tree/master/com/jrestless is obsolete, too now that it's been merged into JRestless.